### PR TITLE
added pwm oscillator + unit tests

### DIFF
--- a/src/synthesis/oscillators/ioscillator.h
+++ b/src/synthesis/oscillators/ioscillator.h
@@ -5,19 +5,17 @@
 namespace BOSSCorp::Synthesis::Oscillators
 {
 
-    class IOscillator : public ISteppable
-    {
-        private:
-        float _shiftTime = 0;
-        protected:
-        float _frequency;
-        float _amplitude;
-        
-
-        public:
-        virtual void configure(float frequency, float amplitude = 1, float phaseShift = 0) { _frequency = frequency; _amplitude = amplitude, _shiftTime = (1.0 / frequency * phaseShift); }
-        virtual void reset() { setTime(_shiftTime); }
-        float frequency() const { return _frequency; }
-    };
+class IOscillator : public ISteppable
+{
+private:
+    float _shiftTime = 0;
+    protected:
+    float _frequency;
+    float _amplitude;
+public:
+    virtual void configure(float frequency, float amplitude = 1, float phaseShift = 0) { _frequency = frequency; _amplitude = amplitude, _shiftTime = (1.0 / frequency * phaseShift); }
+    virtual void reset() { setTime(_shiftTime); }
+    float frequency() const { return _frequency; }
+};
 
 }

--- a/src/synthesis/oscillators/pwm_configuration.h
+++ b/src/synthesis/oscillators/pwm_configuration.h
@@ -6,9 +6,7 @@ namespace BOSSCorp::Synthesis::Oscillators
 
 struct PWMConfiguration
 {
-public:
-    float dutyCycle;
-    float offset;
+    float dutyCycle = 0.5f;
 };
 
 } // end BOSSCorp::Synthesis::Oscillators

--- a/src/synthesis/oscillators/pwm_oscillator.cpp
+++ b/src/synthesis/oscillators/pwm_oscillator.cpp
@@ -1,11 +1,24 @@
 #include "pwm_oscillator.h"
-
+#include <cmath>
 namespace BOSSCorp::Synthesis::Oscillators
 {
 
-void PWMOscillator::process()
+PWMOscillator::PWMOscillator(const PWMConfiguration& pwmConfiguration)
+    : _configuration(pwmConfiguration)
 {
+}
 
+float PWMOscillator::next()
+{
+    float wavetime = 1.0 / frequency();
+    float output = 0.5;
+
+    if(fmod(time(), wavetime) > _configuration.dutyCycle * wavetime)
+    {
+        output = -output;
+    }
+
+    return output;
 }
 
 } // end namespace BOSSCorp::Synthesis::Oscillators

--- a/src/synthesis/oscillators/pwm_oscillator.h
+++ b/src/synthesis/oscillators/pwm_oscillator.h
@@ -1,13 +1,17 @@
 #pragma once
 #include "ioscillator.h"
-
+#include "pwm_configuration.h"
 namespace BOSSCorp::Synthesis::Oscillators
 {
 
 class PWMOscillator : public IOscillator
 {
+private:
+    const PWMConfiguration& _configuration;
+protected:
+    virtual float next();
 public:
-    void process();
+    explicit PWMOscillator(const PWMConfiguration& pwmConfiguration);    
 };
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,3 +37,4 @@ add_test_executable(adsr-envelope-tests "adsr-envelope-tests.cpp" "synthesis/env
 add_test_executable(sawtooth-oscillator-tests "sawtooth-oscillator-tests.cpp" "synthesis/oscillators/sawtooth_oscillator.cpp" "synthesis/oscillators/reverse_sawtooth_oscillator.cpp")
 add_test_executable(reverse-sawtooth-oscillator-tests "reverse-sawtooth-oscillator-tests.cpp" "synthesis/oscillators/reverse_sawtooth_oscillator.cpp" "synthesis/oscillators/sawtooth_oscillator.cpp")
 add_test_executable(triangle-oscillator-tests "triangle-oscillator-tests.cpp" "synthesis/oscillators/triangle_oscillator.cpp" "synthesis/oscillators/sawtooth_oscillator.cpp")
+add_test_executable(pwm-oscillator-tests "pwm-oscillator-tests.cpp" "synthesis/oscillators/pwm_oscillator.cpp")

--- a/tests/pwm-oscillator-tests.cpp
+++ b/tests/pwm-oscillator-tests.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include "synthesis/oscillators/pwm_oscillator.h"
+
+#include "fft.h"
+
+TEST(SawtoothOscillatorTests, PLOT)
+{
+    using namespace BOSSCorp::Synthesis::Oscillators;
+    PWMConfiguration configuration;
+    configuration.dutyCycle = 0.5;
+
+    PWMOscillator oscillator(configuration);
+
+    autoplot("pwm-50%", oscillator);
+    
+    oscillator.reset();
+    configuration.dutyCycle = 0.75;
+    autoplot("pwm-75%", oscillator);
+
+    oscillator.reset();
+    configuration.dutyCycle = 0.25;
+    autoplot("pwm-25%", oscillator);
+}
+
+TEST(SawtoothOscillatorTests, ConfirmFrequency)
+{
+    using namespace BOSSCorp::Synthesis::Oscillators;
+    PWMConfiguration configuration;
+    configuration.dutyCycle = 0.5;
+
+    PWMOscillator oscillator(configuration);
+
+    int frequencies[] {20, 440, 3000};
+    int size = sizeof(frequencies) / sizeof(frequencies[0]);
+
+    doGlobalFrequencyTest(oscillator, frequencies, size, 5);
+}


### PR DESCRIPTION
added a PWM oscillator.
this oscillator has a PWM configuration reference with the duty cycle in it.

this means that you could create a configuration for each oscillator or share it among all oscillators.
This way, changing your duty cycle through midi or any other system will be applied to all pwm oscillators.