### PR TITLE
added sine oscillator + tests

### DIFF
--- a/src/synthesis/oscillators/sine_oscillator.cpp
+++ b/src/synthesis/oscillators/sine_oscillator.cpp
@@ -1,0 +1,14 @@
+#include "sine_oscillator.h"
+#include <math.h>
+namespace BOSSCorp::Synthesis::Oscillators
+{
+
+float SineOscillator::next()
+{
+    constexpr float pi2 = M_PI * 2;
+
+    return sin(pi2 * frequency() * time()) * 0.5; // amplitude range from -0.5 to +0.5
+}
+
+
+} // end BOSSCorp::Synthesis::Oscillators

--- a/src/synthesis/oscillators/sine_oscillator.h
+++ b/src/synthesis/oscillators/sine_oscillator.h
@@ -6,7 +6,8 @@ namespace BOSSCorp::Synthesis::Oscillators
 
 class SineOscillator : public IOscillator
 {
-    
+protected:
+    virtual float next();
 };
 
 } // end BOSSCorp::Synthesis::Oscillators

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,4 @@ add_test_executable(sawtooth-oscillator-tests "sawtooth-oscillator-tests.cpp" "s
 add_test_executable(reverse-sawtooth-oscillator-tests "reverse-sawtooth-oscillator-tests.cpp" "synthesis/oscillators/reverse_sawtooth_oscillator.cpp" "synthesis/oscillators/sawtooth_oscillator.cpp")
 add_test_executable(triangle-oscillator-tests "triangle-oscillator-tests.cpp" "synthesis/oscillators/triangle_oscillator.cpp" "synthesis/oscillators/sawtooth_oscillator.cpp")
 add_test_executable(pwm-oscillator-tests "pwm-oscillator-tests.cpp" "synthesis/oscillators/pwm_oscillator.cpp")
+add_test_executable(sine-oscillator-tests "sine-oscillator-tests.cpp" "synthesis/oscillators/sine_oscillator.cpp")

--- a/tests/sine-oscillator-tests.cpp
+++ b/tests/sine-oscillator-tests.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include "synthesis/oscillators/sine_oscillator.h"
+#include "fft.h"
+
+TEST(SineOscillatorTests, PLOT)
+{
+    BOSSCorp::Synthesis::Oscillators::SineOscillator oscillator;
+    autoplot("sine", oscillator);
+}
+
+TEST(SineOscillatorTests, ConfirmFrequency)
+{
+    BOSSCorp::Synthesis::Oscillators::SineOscillator oscillator;
+    int frequencies[] {20, 440, 3000};
+    int size = sizeof(frequencies) / sizeof(frequencies[0]);
+
+    doGlobalFrequencyTest(oscillator, frequencies, size, 5);
+}


### PR DESCRIPTION
Added a simple sine wave oscillator.

It might be that this one will run less than optimal on embedded platforms (even with an fpu). 
If a faster one is required, it is possible to implement this on for instance ARM systems using arm_math.h and their special sine function.

In that case I'd make a seperate ARMSineOscillator and use that one instead of the normal SineOscillator.