### PR TITLE
fixed bug, CC::NoteOn and NoteOff were swapped, fewer allocations, en…

### DIFF
--- a/src/midi/enums.h
+++ b/src/midi/enums.h
@@ -53,8 +53,8 @@ enum class Status : uint8_t
 {
     // Channel voice messages. 0b.dddd.nnnn
     // Where d = data bit, n = channel.
-    NoteOn          = 0b10000000,
-    NoteOff         = 0b10010000,
+    NoteOn          = 0b10010000,
+    NoteOff         = 0b10000000,
     AfterTouch      = 0b10100000,
     ControlChange   = 0b10110000,
     ProgramChange   = 0b11000000,

--- a/src/synthesis/envelopes/ienvelope.h
+++ b/src/synthesis/envelopes/ienvelope.h
@@ -13,6 +13,7 @@ protected:
     void finish() { _finished = true; }
 public:
     bool finished() const { return _finished; }
+    virtual void reset() { ISteppable::reset(); _finished = false; }
 }; 
 
 } // end BOSSCorp::Synthesis::Envelopes

--- a/src/synthesis/oscillators/ioscillator.h
+++ b/src/synthesis/oscillators/ioscillator.h
@@ -19,7 +19,7 @@ protected:
 public:
     IOscillator(const Configurations::IOscillatorConfiguration& configuration) : _configuration(configuration) { }
     virtual void configure(float frequency, float amplitude = 1, float phaseShift = 0) { _frequency = frequency; _amplitude = amplitude; _waveTime = 1.0f / frequency; _shiftTime = (_waveTime * phaseShift); }
-    virtual void reset()    { time(_shiftTime);  }
+    virtual void reset()    { time(_shiftTime); ISteppable::reset(); }
     float frequency() const { return _frequency; }
     float amplitude() const { return _amplitude * _configuration.amplitude; }
     float wavetime()  const { return _waveTime;  }

--- a/src/synthesis/sound_sources/isound_source.h
+++ b/src/synthesis/sound_sources/isound_source.h
@@ -14,17 +14,21 @@ private:
     int8_t _octave;
     Midi::Note _note;
     float _amplitude;
+    bool _ignore;
 protected:
     Envelopes::IEnvelope& _envelope;
     float deltaTime() const { return _lastDeltaTime; }
 public:
     ISoundSource(Envelopes::IEnvelope& envelope) : _lastDeltaTime(0), _octave(0), _note(Midi::Note::A), _amplitude(0), _envelope(envelope) { }
     virtual float next(float deltaTime) { _lastDeltaTime = deltaTime; return ISteppable::next(deltaTime); }
-    virtual void reset() { _envelope.reset(); ISteppable::reset(); }
+    virtual void reset() { _envelope.reset(); ISteppable::reset(); ignore(false);}
     virtual void configure(Midi::Note note, int8_t octave, float amplitude) { _note = note; _octave = octave; _amplitude = amplitude; }
     virtual bool finished() { return _envelope.finished(); }
     int8_t octave() const { return _octave; } 
     Midi::Note note() const { return _note; }
+    bool ignore() const { return _ignore; }
+    void ignore(bool value) { _ignore = value; } // to not use this source. for instance when no key is pressed.
+    virtual void release() {}
 };
 
 } // end BOSSCorp::Synthesis::SoundSources

--- a/src/synthesis/synthesizers/isynthesizer.h
+++ b/src/synthesis/synthesizers/isynthesizer.h
@@ -9,6 +9,7 @@ class ISynthesizer {
 public:
     virtual void process(Buffer& buffer) = 0;
 
+	virtual void init() {}
 
     // Resets to cold boot
     virtual void reset() {}

--- a/src/synthesis/synthesizers/synthesizer.h
+++ b/src/synthesis/synthesizers/synthesizer.h
@@ -11,7 +11,7 @@ namespace BOSSCorp::Synthesis::Synthesizers
 
 class Synthesizer : public ISynthesizer
 {
-private:
+protected:
     std::vector<SoundSources::ISoundSource*> _soundSources {};
     
     Envelopes::ADSRConfiguration                             _adsrConfig;
@@ -30,6 +30,8 @@ private:
     void cleanOldSources();
 
     float next(float deltaT);
+
+    virtual SoundSources::ISoundSource* getNewSoundSource();
 public:
     const int MaxAttackSeconds  = 3;
     const int MaxDecaySeconds   = 3;
@@ -39,7 +41,7 @@ public:
     ~Synthesizer();
     virtual void process(Buffer& buffer);
 
-
+    virtual void init();
     // velocity 0 = silence, 1 = bottom out.
     virtual void noteOn(Midi::Note note, int8_t octave, float velocity);
     virtual void noteOff(Midi::Note note, int8_t octave, float velocity);
@@ -52,6 +54,9 @@ public:
     virtual void  volume(float value) { _volume = value; }
 
     virtual void reset();
+
+    virtual void allNotesOff();
+
 };
 
 } // end BOSSCorp::Synthesis::Synthesizers


### PR DESCRIPTION
…velopes were not properly reset and added the 'ignore' option

There was a mistake in the MIDI enums where note press and release were swapped, so notes would sound when you release, but releasing the note after that wasn't happening anymore. (as it happened before the note on)

fewer allocations, sound sources are now reused instead of thrown away and recreated again. this should prevent memory fragmentation, especially on micro controller targets.